### PR TITLE
Cleaner graphs

### DIFF
--- a/src/graph/breakends.rs
+++ b/src/graph/breakends.rs
@@ -119,7 +119,7 @@ pub fn main_breakends(args: BreakendArgs) -> anyhow::Result<()> {
         eprintln!("Writing dot files");
         std::fs::create_dir_all(dot_dir)?;
         for (event_id, component) in events.into_iter().map(|event| (event.id, event.subgraph)) {
-            let dot = plot::graph_to_dot(&component);
+            let dot = plot::graph_to_dot(&component, &bam_header);
             let path = dot_dir.join(format!("{event_id}.dot", event_id = event_id));
             std::fs::write(path, dot)?;
         }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -316,9 +316,7 @@ pub struct EdgeInfo {
 impl Debug for EdgeInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!(
-            "cov:    {:.2}\n\
-                splits: {}\n\
-                dist:   {}\n",
+            "cov: {:.2}, splits: {}, dist: {}",
             self.coverage, self.num_split_reads, self.distance
         ))
     }


### PR DESCRIPTION
Layout graphs from left to right, sorted by reference ID and genomic locations.
(In the future, group by reference ID and enclose in `{ ... }`, such that graphs with multiple reference IDs can spread them vertically)