### PR TITLE
perf: reduce memory footprint of `cyrcular graph breakends` command

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -8,7 +8,7 @@ use num_traits::{One, Zero};
 use rayon::prelude::*;
 
 pub(crate) type ReferenceId = u32;
-pub(crate) type Count = i32;
+pub(crate) type Count = i16;
 pub(crate) type ReadDepth = HashMap<ReferenceId, Vec<Count>>;
 pub(crate) type SplitReadStorage = HashMap<String, Vec<Record>>;
 pub(crate) type RecordTree<'a> = ArrayBackedIntervalTree<usize, &'a Record>;


### PR DESCRIPTION
* reduce max usable read coverage to 32767 by switching Count to i16 from i32, this just about halves memory usage